### PR TITLE
Add User-Agent

### DIFF
--- a/internal/certlib/api.go
+++ b/internal/certlib/api.go
@@ -349,6 +349,7 @@ func DownloadEntries(ctx context.Context, ctlog *CTLogInfo, start, end int) (*En
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
+	req.Header.Set("User-Agent", "rxtls (+https://github.com/x-stp/rxtls)")
 
 	// Make the request with retry logic
 	var resp *http.Response


### PR DESCRIPTION
This helps log operators contact accidentally misbehaving clients, and prioritize open source improvements based on traffic proportion.