### PR TITLE
fix: update GoReleaser config and add Docker multi-arch support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git files
+.git
+.gitignore
+
+# Documentation
+*.md
+docs/
+LICENSE
+
+# Build artifacts
+dist/
+*.exe
+rxtls
+
+# Development files
+.goreleaser.yaml
+.golangci.yml
+Makefile
+.github/
+
+# Test files
+*_test.go
+testdata/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          install-only: true
-      
-      - name: Run GoReleaser
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goreleaser release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,7 +64,8 @@ builds:
 
 # Archive configuration
 archives:
-  - id: rxtls
+  - ids:
+      - rxtls
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
@@ -162,11 +163,14 @@ release:
   # Name template
   name_template: "{{ .Tag }}"
 
-# Docker configuration
+# Docker configuration with multi-arch support
 dockers:
   - image_templates:
-      - "ghcr.io/x-stp/rxtls:{{ .Tag }}"
-      - "ghcr.io/x-stp/rxtls:latest"
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-amd64"
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-arm64"
+    
+    # Use specific binary
+    use: buildx
     
     # Build context
     goos: linux
@@ -185,18 +189,55 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/x-stp/rxtls"
       - "--label=org.opencontainers.image.licenses=AGPL-3.0"
       - "--platform=linux/amd64"
+  
+  - image_templates:
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-arm64"
+    
+    # Use specific binary
+    use: buildx
+    
+    # Build context
+    goos: linux
+    goarch: arm64
+    
+    # Dockerfile
+    dockerfile: Dockerfile
+    
+    # Build flags
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/x-stp/rxtls"
+      - "--label=org.opencontainers.image.licenses=AGPL-3.0"
+      - "--platform=linux/arm64"
+
+# Docker manifest for multi-arch support
+docker_manifests:
+  - name_template: "ghcr.io/x-stp/rxtls:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-amd64"
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-arm64"
+  
+  - name_template: "ghcr.io/x-stp/rxtls:latest"
+    image_templates:
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-amd64"
+      - "ghcr.io/x-stp/rxtls:{{ .Tag }}-arm64"
 
 # Homebrew tap configuration
 brews:
-  - repository:
+  - tap:
       owner: x-stp
       name: homebrew-rxtls
     
     # Folder inside the repository to put the formula
     folder: Formula
     
-    # Formula name
-    name: rxtls
+    # Binaries to install
+    ids:
+      - rxtls
     
     # Homepage
     homepage: "https://github.com/x-stp/rxtls"


### PR DESCRIPTION
- Update GoReleaser action to v6 in workflow
- Fix deprecated syntax: repository->tap, formula name->ids
- Add Docker multi-arch support for amd64 and arm64
- Update Dockerfile with buildx ARGs for cross-compilation
- Add docker_manifests for multi-arch image manifests
- Add .dockerignore to optimize build context